### PR TITLE
Increase data row limit

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -65,7 +65,12 @@
                                 "to": "Destination"
                             }
                         }
-                    ]
+                    ],
+                    "dataReductionAlgorithm": {
+                        "top": {
+                            "count": 30000
+                        }
+                    }
                 },
                 "values": {
                     "select": [


### PR DESCRIPTION
## Summary
- allow up to 30k rows in matrix data to avoid Power BI "too many values" truncation message

## Testing
- `npm run lint`
- `npm test` *(fails: Running as root without --no-sandbox is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68935e8ef1cc8330960e9925c54d5a9e