### PR TITLE
Fix compact layout clipping

### DIFF
--- a/src/sankeyDiagram.ts
+++ b/src/sankeyDiagram.ts
@@ -1333,6 +1333,19 @@ export class SankeyDiagram implements IVisual {
                     }
                 }
             }
+
+            // Ensure nodes fit within viewport after adjustments
+            const firstNode = columnNodes[0];
+            if (firstNode.y < 0) {
+                const offset = -firstNode.y;
+                columnNodes.forEach(node => node.y += offset);
+            }
+
+            const lastNode = columnNodes[columnNodes.length - 1];
+            const bottomOverflow = lastNode.y + lastNode.height - this.viewport.height;
+            if (bottomOverflow > 0) {
+                columnNodes.forEach(node => node.y -= bottomOverflow);
+            }
             return;
         }
 


### PR DESCRIPTION
## Summary
- ensure nodes are shifted to stay within viewport when compact layout is enabled

## Testing
- `npm run lint`
- `npm test` *(fails: Running as root without --no-sandbox is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68937d52b0a08330a79dfc52d9afd181